### PR TITLE
fix transform of mouse position with rotated capture area

### DIFF
--- a/addons/control3d/src/Control3D.cs
+++ b/addons/control3d/src/Control3D.cs
@@ -160,7 +160,7 @@ public partial class Control3D : Node3D
 		// If the mouse is inside the panel,
 		// we need to convert the mouse position to the 2D world.
 		mousePos3D = mouseInside
-			? CaptureArea.GlobalTransform.AffineInverse() * new Vector3(mousePos3D.X, mousePos3D.Y, 0)
+			? CaptureArea.GlobalTransform.AffineInverse() * new Vector3(mousePos3D.X, mousePos3D.Y, mousePos3D.Z)
 			: new(_halfMeshSize.X, -_halfMeshSize.Y, 0);
 
 		Vector2 mousePos2D = MouseTo2DWorld(mousePos3D);


### PR DESCRIPTION
Was kinda wondering why the third dimension for the transform was left out?

I tried using this with a rotated capture area and it did not work as expected. Adding in the z axis fixed this.

Just beware that I did not actually test the cs-Code, as I translated it to gdscript for myself ^^

Not sure about the mouse"Outside"-Part, as it only seems to be triggered when I move the mouse very fast.